### PR TITLE
[#3] FEAT : Base Entity 추가

### DIFF
--- a/src/main/java/com/knud4/an/Base/BaseEntity.java
+++ b/src/main/java/com/knud4/an/Base/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.knud4.an.Base;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity{
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+}

--- a/src/main/java/com/knud4/an/Base/BaseTimeEntity.java
+++ b/src/main/java/com/knud4/an/Base/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.knud4.an.Base;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}


### PR DESCRIPTION
모든 Entity 에 상속되는 Base Entity 를 추가합니다.

JPA Auditing 으로 Entity 생성을 추적하고, MappedSuperClass 로 매핑 정보만 제공하여 따로 테이블을 생성하지 않는 class 입니다.

++ 추후에 Member Entity 추가가 끝나면 세션 작업을 통해 ~~By 에 정상적으로 값이 들어갈 수 있게 기능을 추가해야합니다.