### PR TITLE
Feat: spring security 추가 및 추가에 따른 기존 클래스 일부 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+//    none commit
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-test'
+
+    implementation group: 'org.json', name: 'json', version: '20220320'
+
+
     runtimeOnly 'com.h2database:h2'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/knud4/an/account/entity/Account.java
+++ b/src/main/java/com/knud4/an/account/entity/Account.java
@@ -34,11 +34,12 @@ public class Account {
     private Role role = Role.ROLE_NOT_SIGNED;
 
     @Builder
-    public Account(House house, Line line, String email, String username, String password) {
+    public Account(House house, Line line, String email, String username, String password, Role role) {
         this.house = house;
         this.line = line;
         this.email = email;
         this.username = username;
         this.password = password;
+        this.role = role;
     }
 }

--- a/src/main/java/com/knud4/an/config/SecurityConfigure.java
+++ b/src/main/java/com/knud4/an/config/SecurityConfigure.java
@@ -1,0 +1,45 @@
+package com.knud4.an.config;
+
+import com.knud4.an.security.filter.JwtAuthenticationFilter;
+import com.knud4.an.utils.cookie.CookieUtil;
+import com.knud4.an.security.provider.JwtProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+public class SecurityConfigure {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    JwtAuthenticationFilter jwtAuthenticationFilter(JwtProvider jwtProvider, CookieUtil cookieUtil) {
+        return new JwtAuthenticationFilter(jwtProvider, cookieUtil);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           JwtProvider jwtProvider,
+                                           CookieUtil cookieUtil) throws Exception {
+        return http
+                .httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/v1/**").permitAll()
+                .antMatchers("/test").hasRole("USER")
+                .antMatchers("/api/user/**").hasRole("USER")
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter(jwtProvider, cookieUtil),
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/knud4/an/security/details/AccountDetails.java
+++ b/src/main/java/com/knud4/an/security/details/AccountDetails.java
@@ -1,0 +1,17 @@
+package com.knud4.an.security.details;
+
+import com.knud4.an.account.entity.Account;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+
+public class AccountDetails extends User {
+
+    public AccountDetails(Account account) {
+        super(account.getEmail(), account.getPassword(),
+                AuthorityUtils.createAuthorityList(account.getRole().toString()));
+    }
+
+    public String getEmail() {
+        return this.getUsername();
+    }
+}

--- a/src/main/java/com/knud4/an/security/details/AccountDetailsService.java
+++ b/src/main/java/com/knud4/an/security/details/AccountDetailsService.java
@@ -1,0 +1,25 @@
+package com.knud4.an.security.details;
+
+import com.knud4.an.account.entity.Account;
+import com.knud4.an.account.repository.AccountRepository;
+import com.knud4.an.security.details.AccountDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountDetailsService implements UserDetailsService {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Account account = accountRepository.findAccountByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일과 일치하는 계정이 없습니다."));
+
+        return new AccountDetails(account);
+    }
+}

--- a/src/main/java/com/knud4/an/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/knud4/an/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.knud4.an.security.filter;
+
+import com.knud4.an.utils.cookie.CookieUtil;
+import com.knud4.an.security.provider.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final JwtProvider jwtProvider;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String token = null;
+        Authentication authenticate;
+
+        HttpServletRequest req = (HttpServletRequest)request;
+        HttpServletResponse res = (HttpServletResponse)response;
+
+        Cookie accountTokenCookie = cookieUtil.getCookie(req, "account_token");
+        if (accountTokenCookie != null) {
+            token = accountTokenCookie.getValue();
+        }
+
+        if(token != null && !jwtProvider.isTokenExpired(token)) {
+            try {
+                String emailFromToken = jwtProvider.getEmailFromToken(token);
+                authenticate = jwtProvider
+                        .authenticate(new UsernamePasswordAuthenticationToken(emailFromToken, ""));
+
+                SecurityContextHolder.getContext().setAuthentication(authenticate);
+            } catch(Exception e) {
+                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                res.setContentType("application/json");
+                res.setCharacterEncoding("UTF-8");
+
+                JSONObject resJson = new JSONObject();
+                resJson.put("code", 401);
+                resJson.put("message", e.getMessage());
+
+                res.getWriter().write(resJson.toString());
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## PR 요약

1. spring security 추가 및 추가에 따른 기존 클래스 일부 수정

## 변경 사항

1. security 및 jsonObject 의존성을 추가합니다.
2. 기존 JWTUtil 클래스가 provider 로 제공됨에 따라서 클래스명을 수정하였습니다. 
-> 카멜 케이스에서 약어의 경우 모두 대문자로 표기하지 않는 방식으로 바꿉니다.
3. 권한의 경우 최초 생성시에 builder 를 통해 주입해주기 위해서 생성자 파라미터에 추가하였습니다.
4. filter - authenticationProvider - userDetailsService - userDetail 에 해당하는 클래스를 추가합니다.

## 참고 사항

1. 자세한 인증/인가 로직은 프로젝트 협업 문서에 업로드 하겠습니다.
