### PR TITLE
Account/Profile 필터 분리, Account/Profile Interceptor 추가

### DIFF
--- a/src/main/java/com/knud4/an/auth/util/AccountTokenInterceptor.java
+++ b/src/main/java/com/knud4/an/auth/util/AccountTokenInterceptor.java
@@ -1,0 +1,32 @@
+package com.knud4.an.auth.util;
+
+import com.knud4.an.exception.NotFoundException;
+import com.knud4.an.security.provider.JwtProvider;
+import com.knud4.an.utils.jwt.JwtExtractor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+public class AccountTokenInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
+        String accountToken = JwtExtractor.extractJwt(request);
+
+        String email = jwtProvider.getEmailFromToken(accountToken);
+        Long accountId = jwtProvider.getAccountIdFromToken(accountToken);
+
+        request.setAttribute("accountId", accountId);
+        request.setAttribute("email", email);
+        return true;
+    }
+}

--- a/src/main/java/com/knud4/an/auth/util/ProfileTokenInterceptor.java
+++ b/src/main/java/com/knud4/an/auth/util/ProfileTokenInterceptor.java
@@ -1,0 +1,35 @@
+package com.knud4.an.auth.util;
+
+import com.knud4.an.exception.NotFoundException;
+import com.knud4.an.security.provider.JwtProvider;
+import com.knud4.an.utils.jwt.JwtExtractor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileTokenInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
+        String profileToken = JwtExtractor.extractJwt(request);
+
+        String email = jwtProvider.getEmailFromToken(profileToken);
+        Long profileId = jwtProvider.getProfileIdFromToken(profileToken);
+        Long accountId = jwtProvider.getAccountIdFromToken(profileToken);
+
+        request.setAttribute("email", email);
+        request.setAttribute("accountId", accountId);
+        request.setAttribute("profileId", profileId);
+
+        return true;
+    }
+}

--- a/src/main/java/com/knud4/an/config/SecurityConfigure.java
+++ b/src/main/java/com/knud4/an/config/SecurityConfigure.java
@@ -1,16 +1,26 @@
 package com.knud4.an.config;
 
+import com.knud4.an.exception.CustomAccessDeniedHandler;
 import com.knud4.an.security.filter.JwtAuthenticationFilter;
+import com.knud4.an.security.filter.JwtProfileAuthenticationFilter;
 import com.knud4.an.utils.cookie.CookieUtil;
 import com.knud4.an.security.provider.JwtProvider;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @EnableWebSecurity
 public class SecurityConfigure {
@@ -20,26 +30,71 @@ public class SecurityConfigure {
         return new BCryptPasswordEncoder();
     }
 
-    JwtAuthenticationFilter jwtAuthenticationFilter(JwtProvider jwtProvider, CookieUtil cookieUtil) {
-        return new JwtAuthenticationFilter(jwtProvider, cookieUtil);
+    JwtAuthenticationFilter jwtAuthenticationFilter(JwtProvider jwtProvider) {
+        return new JwtAuthenticationFilter(jwtProvider);
+    }
+
+    JwtProfileAuthenticationFilter jwtProfileAuthenticationFilter(JwtProvider jwtProvider) {
+        return new JwtProfileAuthenticationFilter(jwtProvider);
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http,
+    public SecurityFilterChain accountFilterChain(HttpSecurity http,
                                            JwtProvider jwtProvider,
                                            CookieUtil cookieUtil) throws Exception {
+        return setJwtHttpSecurity(http)
+                .requestMatchers()
+                .antMatchers("/api/v1/auth/profile/**")
+                .antMatchers("/api/v1/account/**")
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/v1/auth/profile/**").hasRole("USER")
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(new AuthenticationEntryPoint() {
+                    @Override
+                    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+                        response.sendError(403, "인증 토큰 정보가 잘못되었습니다.");
+                    }
+                })
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public SecurityFilterChain profileFilterChain(HttpSecurity http,
+                                           JwtProvider jwtProvider,
+                                           CookieUtil cookieUtil) throws Exception {
+        return setJwtHttpSecurity(http)
+                .requestMatchers()
+                .antMatchers("/api/v1/profile/**")
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/v1/profile/**").hasRole("USER")
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(new AuthenticationEntryPoint() {
+                    @Override
+                    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+                        response.sendError(403, "인증 토큰 정보가 잘못되었습니다.");
+                    }
+                })
+                .and()
+                .addFilterBefore(jwtProfileAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    private HttpSecurity setJwtHttpSecurity(HttpSecurity http) throws Exception{
         return http
                 .httpBasic().disable()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/v1/**").permitAll()
-                .antMatchers("/test").hasRole("USER")
-                .antMatchers("/api/user/**").hasRole("USER")
-                .and()
-                .addFilterBefore(jwtAuthenticationFilter(jwtProvider, cookieUtil),
-                        UsernamePasswordAuthenticationFilter.class)
-                .build();
+                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .and();
     }
 }

--- a/src/main/java/com/knud4/an/config/WebConfig.java
+++ b/src/main/java/com/knud4/an/config/WebConfig.java
@@ -1,16 +1,37 @@
 package com.knud4.an.config;
 
+import com.knud4.an.auth.util.AccountTokenInterceptor;
+import com.knud4.an.auth.util.ProfileTokenInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AccountTokenInterceptor accountTokenInterceptor;
+    private final ProfileTokenInterceptor profileTokenInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("*")
-                .allowedMethods("GET", "POST", "DELETE", "PUT");
+                .allowedMethods("GET", "POST", "DELETE", "PUT")
+                .allowedHeaders("*")
+                .exposedHeaders("*");
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(accountTokenInterceptor).addPathPatterns(
+                "/api/v1/account/**", "/api/v1/auth/profile/**"
+        );
+
+        registry.addInterceptor(profileTokenInterceptor).addPathPatterns(
+                "/api/v1/profile/**"
+        );
     }
 }

--- a/src/main/java/com/knud4/an/security/filter/JwtProfileAuthenticationFilter.java
+++ b/src/main/java/com/knud4/an/security/filter/JwtProfileAuthenticationFilter.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtProfileAuthenticationFilter extends GenericFilterBean {
 
     private final JwtProvider jwtProvider;
 
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
         token = JwtExtractor.extractJwt(req);
 
-        if(token != null && !jwtProvider.isAccountTokenExpired(token)) {
+        if(token != null && !jwtProvider.isProfileTokenExpired(token)) {
             try {
                 String emailFromToken = jwtProvider.getEmailFromToken(token);
                 authenticate = jwtProvider

--- a/src/main/java/com/knud4/an/utils/jwt/JwtExtractor.java
+++ b/src/main/java/com/knud4/an/utils/jwt/JwtExtractor.java
@@ -1,0 +1,20 @@
+package com.knud4.an.utils.jwt;
+
+import org.apache.logging.log4j.util.Strings;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class JwtExtractor {
+
+    public static final String JWT_HEADER_NAME = "Authorization";
+    public static final String JWT_PREFIX = "Bearer ";
+
+    public static String extractJwt(HttpServletRequest req) {
+        String authHeader = req.getHeader(JWT_HEADER_NAME);
+        if (authHeader != null && authHeader.startsWith(JWT_PREFIX)) {
+            return authHeader.replace(JWT_PREFIX, "");
+        }
+
+        return Strings.EMPTY;
+    }
+}


### PR DESCRIPTION
## PR 요약

1. Account/Profile 필터를 분리합니다.
2. Account/Profile Interceptor 추가합니다.

## 변경 사항

1. 요청에서 Authorization 헤더 값을 추출하는 JwtExtractor Class 추가
2. 토큰에서 필요한 Claim 을 추출하는 Interceptor Class 추가
3. url 별 서로다른 인증 토큰(account, profile) 을 사용하기 떄문에 인증/인가 필터를 분리
-> 각 필터에서 토큰 claim 유효성 검사를 하고, 인가 과정 진행


## 참고 사항

1.
