### PR TITLE
Feat: Community와 Comment 간 연관관계 추가

### DIFF
--- a/src/main/java/com/knud4/an/comment/entity/Comment.java
+++ b/src/main/java/com/knud4/an/comment/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.knud4.an.comment.entity;
 
 import com.knud4.an.Base.BaseEntity;
+import com.knud4.an.community.entity.Community;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,9 +20,8 @@ public class Comment extends BaseEntity {
 
     // Member와의 연관관계 설정 필요
 
-    // Community와의 연관관계 설정 필요
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    private Community community;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Community community;
 
     private Long likes;
 }

--- a/src/main/java/com/knud4/an/comment/repository/CommentRepository.java
+++ b/src/main/java/com/knud4/an/comment/repository/CommentRepository.java
@@ -17,9 +17,10 @@ public class CommentRepository {
         em.persist(comment);
     }
 
-    // 커뮤니티 글 아이디로 모든 댓글 조회 구현 필요
     public List<Comment> findAllByCommunityId(Long communityId) {
-        return null;
+        return em.createQuery("select c from Comment c where c.community = :communityId", Comment.class)
+                .setParameter("communityId", communityId)
+                .getResultList();
     }
 
     public void delete(Comment comment) {

--- a/src/main/java/com/knud4/an/community/entity/Community.java
+++ b/src/main/java/com/knud4/an/community/entity/Community.java
@@ -1,11 +1,15 @@
 package com.knud4.an.community.entity;
 
 import com.knud4.an.board.Board;
+import com.knud4.an.comment.entity.Comment;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import java.util.List;
 
 @Entity
 @Getter
@@ -14,9 +18,10 @@ public class Community extends Board {
 
     private Category category;
 
-    // Comment와의 연관관계 추가 필요
+    @OneToMany(mappedBy = "community")
+    private List<Comment> comments;
 
     private Long commentCnt;
 
-    private Long like;
+    private Long likes;
 }

--- a/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
+++ b/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CommunityRepository {
 
-    private EntityManager em;
+    private final EntityManager em;
 
     public void create(Community community) {
         em.persist(community);


### PR DESCRIPTION
## PR 요약

1. Community와 Comment 간 연관관계 추가

## 변경 사항

1. Community Entity와 Comment Entity 간 연관관계를 추가합니다.
2. Comment Repository에서 findAllByCommunityId를 추가합니다.

## 참고 사항

1. 몇몇 도메인과 Member와의 연관관계 설정 예정입니다.
