### PR TITLE
Feat: Board, Comment에 Profile과의 연관관계 추가

### DIFF
--- a/src/main/java/com/knud4/an/board/Board.java
+++ b/src/main/java/com/knud4/an/board/Board.java
@@ -1,11 +1,10 @@
 package com.knud4.an.board;
 
 import com.knud4.an.Base.BaseEntity;
+import com.knud4.an.account.entity.Profile;
 import lombok.Getter;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 
 @Getter
 @MappedSuperclass
@@ -18,7 +17,8 @@ public class Board extends BaseEntity {
 
     private String content;
 
-//    private Member writer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Profile writer;
 
     private Range range;
 }

--- a/src/main/java/com/knud4/an/comment/entity/Comment.java
+++ b/src/main/java/com/knud4/an/comment/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.knud4.an.comment.entity;
 
 import com.knud4.an.Base.BaseEntity;
+import com.knud4.an.account.entity.Profile;
 import com.knud4.an.community.entity.Community;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,7 +19,8 @@ public class Comment extends BaseEntity {
 
     private String text;
 
-    // Member와의 연관관계 설정 필요
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Profile writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Community community;


### PR DESCRIPTION
## PR 요약

1. Board, Comment에 Profile과의 연관관계 추가

## 변경 사항

1. Board Entity에 Profile 연관관계 추가합니다.
2. Comment Entity에 Profile 연관관계 추가합니다.

## 참고 사항

1. 회원이 자기가 쓴 게시물만 모아 보는 기능이 필요한 경우, 양방향 연관관계 설정이 필요합니다.
