### PR TITLE
Refactor: Range 도메인을 Board에서 Community로 이동 및 Notice range 필드 수정

### DIFF
--- a/src/main/java/com/knud4/an/board/Board.java
+++ b/src/main/java/com/knud4/an/board/Board.java
@@ -2,11 +2,9 @@ package com.knud4.an.board;
 
 import com.knud4.an.Base.BaseEntity;
 import com.knud4.an.account.entity.Profile;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import com.knud4.an.community.entity.Range;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
 
@@ -25,8 +23,6 @@ public abstract class Board extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Profile writer;
 
-    private Range range;
-
     protected void setTitle(String title) {
         this.title = title;
     }
@@ -39,7 +35,4 @@ public abstract class Board extends BaseEntity {
         this.writer = writer;
     }
 
-    protected void setRange(Range range) {
-        this.range = range;
-    }
 }

--- a/src/main/java/com/knud4/an/board/Range.java
+++ b/src/main/java/com/knud4/an/board/Range.java
@@ -1,5 +1,0 @@
-package com.knud4.an.board;
-
-public enum Range {
-    ALL, LINE
-}

--- a/src/main/java/com/knud4/an/community/entity/Community.java
+++ b/src/main/java/com/knud4/an/community/entity/Community.java
@@ -2,7 +2,7 @@ package com.knud4.an.community.entity;
 
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.board.Board;
-import com.knud4.an.board.Range;
+import com.knud4.an.comment.entity.Comment;
 import com.knud4.an.comment.entity.CommunityComment;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,17 +28,19 @@ public class Community extends Board {
 
     private Long likes;
 
+    private Range range;
+
     @Builder
     public Community(String title, String content, Profile writer,
-                     Range range, Category category,
-                     Long commentCnt, Long likes) {
+                     Category category, Long commentCnt, Long likes, Range range) {
         this.setContent(content);
         this.setTitle(title);
         this.setWriter(writer);
-        this.setRange(range);
 
         this.category = category;
         this.commentCnt = commentCnt;
         this.likes = likes;
+        this.range = range;
     }
+
 }

--- a/src/main/java/com/knud4/an/community/entity/Range.java
+++ b/src/main/java/com/knud4/an/community/entity/Range.java
@@ -1,0 +1,5 @@
+package com.knud4.an.community.entity;
+
+public enum Range {
+    ALL, LINE
+}

--- a/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
+++ b/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
@@ -1,6 +1,6 @@
 package com.knud4.an.community.repository;
 
-import com.knud4.an.board.Range;
+import com.knud4.an.community.entity.Range;
 import com.knud4.an.community.entity.Category;
 import com.knud4.an.community.entity.Community;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +28,9 @@ public class CommunityRepository {
         return em.createQuery("select c from Community c", Community.class).getResultList();
     }
 
-    public List<Community> findByRange(Range range) {
-        return em.createQuery("select c from Community c where c.range = :range", Community.class)
-                .setParameter("range", range)
+    public List<Community> findByLine(Long lineId) {
+        return em.createQuery("select c from Community c where c.writer.account.line = :lineId", Community.class)
+                .setParameter("lineId", lineId)
                 .getResultList();
     }
 

--- a/src/main/java/com/knud4/an/notice/entity/Notice.java
+++ b/src/main/java/com/knud4/an/notice/entity/Notice.java
@@ -2,13 +2,16 @@ package com.knud4.an.notice.entity;
 
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.board.Board;
-import com.knud4.an.board.Range;
+import com.knud4.an.community.entity.Range;
+import com.knud4.an.line.entity.Line;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
 import java.time.LocalDateTime;
 
 @Entity
@@ -17,13 +20,16 @@ import java.time.LocalDateTime;
 public class Notice extends Board {
     private LocalDateTime expiredDate;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Line releaseLine;  // null이면 전체공개
+
     @Builder
-    public Notice(String title, String content, Profile writer, Range range, LocalDateTime expiredDate) {
+    public Notice(String title, String content, Profile writer, Range range, LocalDateTime expiredDate, Line releaseLine) {
         this.setContent(content);
         this.setTitle(title);
         this.setWriter(writer);
-        this.setRange(range);
 
         this.expiredDate = expiredDate;
+        this.releaseLine = releaseLine;
     }
 }

--- a/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
@@ -1,6 +1,5 @@
 package com.knud4.an.notice.repository;
 
-import com.knud4.an.board.Range;
 import com.knud4.an.notice.entity.Notice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -37,16 +36,16 @@ public class NoticeRepository {
                 .getResultList();
     }
 
-    public List<Notice> findByRange(Range range) {
-        return em.createQuery("select n from Notice n where n.range = :range", Notice.class)
-                .setParameter("range", range)
+    public List<Notice> findByLine(String lineId) {
+        return em.createQuery("select n from Notice n where n.releaseLine = :lineId", Notice.class)
+                .setParameter("lineId", lineId)
                 .getResultList();
     }
 
-    // 특정 날짜 게시물 vs 특정 날짜 이후 게시물 논의 필요
-    public List<Notice> findAfterCreatedDate(LocalDateTime createdDate) {
-        return em.createQuery("select n from Notice n where n.createdDate >= :createdDate", Notice.class)
-                .setParameter("createdDate", createdDate)
+    public List<Notice> findWithinPeriod(LocalDateTime from, LocalDateTime to) {
+        return em.createQuery("select n from Notice n where n.createdDate >= :from and n.createdDate <= :to", Notice.class)
+                .setParameter("from", from)
+                .setParameter("to", to)
                 .getResultList();
     }
 


### PR DESCRIPTION
## PR 요약

1. Range의 도메인을 Board에서 Community로 이동하고 Notice range 필드를 수정합니다.

## 변경 사항

1. Range의 도메인 Board에서 Community로 이동
2. Notice의 range 필드를 삭제하고 releaseLine 추가
3. Community와 Notice Repository에 findByRange 삭제 및 findByLine 추가

## 참고 사항

1. Notice Entity에서 releaseLine이 null인 경우에는 전체 공개를 의미합니다.
