### PR TITLE
Refactor: 토큰 정책 변경, refresh Token 추가

### DIFF
--- a/src/main/java/com/knud4/an/auth/dto/TokenDTO.java
+++ b/src/main/java/com/knud4/an/auth/dto/TokenDTO.java
@@ -1,0 +1,20 @@
+package com.knud4.an.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TokenDTO {
+    @NotNull
+    private String accessToken;
+    @Nullable
+    private String refreshToken;
+}

--- a/src/main/java/com/knud4/an/auth/dto/account/SignInAccountResponse.java
+++ b/src/main/java/com/knud4/an/auth/dto/account/SignInAccountResponse.java
@@ -1,5 +1,6 @@
 package com.knud4.an.auth.dto.account;
 
+import com.knud4.an.account.entity.Account;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,4 +17,16 @@ public class SignInAccountResponse {
     private Long lineId;
     @NotNull
     private Long houseId;
+    @NotNull
+    private String accessToken;
+    @NotNull
+    private String refreshToken;
+
+    public SignInAccountResponse(Account account, String accessToken, String refreshToken) {
+        this.accountId = account.getId();
+        this.lineId = account.getLine().getId();
+        this.houseId = account.getHouse().getId();
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/knud4/an/auth/dto/profile/SignInProfileResponse.java
+++ b/src/main/java/com/knud4/an/auth/dto/profile/SignInProfileResponse.java
@@ -1,5 +1,7 @@
 package com.knud4.an.auth.dto.profile;
 
+import com.knud4.an.account.entity.Account;
+import com.knud4.an.account.entity.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,4 +18,16 @@ public class SignInProfileResponse {
     private Long profileId;
     @NotNull
     private String name;
+    @NotNull
+    private String accessToken;
+    @NotNull String refreshToken;
+
+
+    public SignInProfileResponse(Profile profile, String accessToken, String refreshToken) {
+        this.accountId = profile.getAccount().getId();
+        this.profileId = profile.getId();
+        this.name = profile.getName();
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/knud4/an/utils/cookie/CookieUtil.java
+++ b/src/main/java/com/knud4/an/utils/cookie/CookieUtil.java
@@ -1,5 +1,6 @@
 package com.knud4.an.utils.cookie;
 
+import com.knud4.an.exception.NotFoundException;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,7 @@ public class CookieUtil {
 
     private final int COOKIE_VALIDATION_SECOND = 1000 * 60 * 60 * 48;
 
-    public ResponseCookie createCookie(String name, String value, int maxAge) {
+    public ResponseCookie createRefreshTokenCookie(String name, String value, int maxAge) {
         return ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .path("/")
@@ -21,7 +22,7 @@ public class CookieUtil {
                 .build();
     }
 
-    public ResponseCookie createCookie(String name, String value) {
+    public ResponseCookie createRefreshTokenCookie(String name, String value) {
         return ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .path("/")
@@ -33,12 +34,15 @@ public class CookieUtil {
 
     public ResponseCookie getCookie(HttpServletRequest req, String name) {
         Cookie[] findCookies = req.getCookies();
-        if (findCookies == null) return null;
+        if (findCookies == null) {
+         throw new NotFoundException("전달된 쿠키가 없습니다.");
+        }
         for (Cookie cookie : findCookies) {
             if (cookie.getName().equals(name)) {
                 return ResponseCookie.from(name, cookie.getValue()).build();
             }
         }
-        return null;
+
+        throw new NotFoundException("쿠키를 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
## PR 요약

1. 기존 쿠키를 통한 인증 토큰 교환에서 Response 를 통한 인증 토큰 교환 방식으로 로직을 수정합니다.

## 변경 사항

1. refresh 토큰을 추가합니다.
2. access, refresh 토큰 갱신 api 를 추가합니다.

## 참고 사항

1. refresh 토큰은 만료시간의 절반 이상이 지나면 access 토큰과 함께 갱신됩니다.
