### PR TITLE
Fix: username 중복 생성 방지, 타 계정 간 profile 이름 중복 허용

### DIFF
--- a/src/main/java/com/knud4/an/account/repository/AccountRepository.java
+++ b/src/main/java/com/knud4/an/account/repository/AccountRepository.java
@@ -74,10 +74,12 @@ public class AccountRepository {
                 .getSingleResult();
     }
 
-    public boolean profileExistsByName(String profileName) {
+    public boolean profileExistsByName(String profileName, Long accountId) {
         return em.createQuery("select count(p) > 0 from Profile p " +
-                "where p.name = :profileName", Boolean.class)
+                "where p.name = :profileName " +
+                        "and p.account.id = :accountId", Boolean.class)
                 .setParameter("profileName", profileName)
+                .setParameter("accountId", accountId)
                 .getSingleResult();
     }
 }

--- a/src/main/java/com/knud4/an/auth/service/AuthService.java
+++ b/src/main/java/com/knud4/an/auth/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
     }
 
     private void validateAccountUsernameDuplicated(String username) {
-        if (accountRepository.accountExistsByEmail(username)) {
+        if (accountRepository.accountExistsByUsername(username)) {
             throw new IllegalStateException("이미 존재하는 아이디 입니다.");
         }
     }
@@ -97,8 +97,8 @@ public class AuthService {
         Account account = accountRepository.findAccountByEmail(accountEmailFromToken)
                 .orElseThrow(() -> new NotFoundException("계정이 존재하지 않습니다."));
 
-        if (accountRepository.profileExistsByName(form.getName())) {
-            throw new IllegalArgumentException("프로필 이름이 중복되었습니다");
+        if (accountRepository.profileExistsByName(form.getName(), account.getId())) {
+            throw new IllegalStateException("프로필 이름이 중복되었습니다");
         }
 
         Profile profile = Profile.builder()


### PR DESCRIPTION
## PR 요약

1. username 중복 생성 방지, 타 계정 간 profile 이름 중복 허용

## 변경 사항

1. 계정 생성 시 중복체크 로직에서 알맞은 메소드 호출
2. profile 이름 존재 여부 확인 시 계정 내에서 확인하는 것으로 로직 수정

## 참고 사항

1.
