### PR TITLE
Refactor: Security 예외 응답 로직 수정, Logging Filter 위치 수정

### DIFF
--- a/src/main/java/com/knud4/an/config/SecurityConfig.java
+++ b/src/main/java/com/knud4/an/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.knud4.an.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knud4.an.exception.handler.JwtAccessDeniedHandler;
 import com.knud4.an.exception.handler.JwtNotAuthenticatedHandler;
 import com.knud4.an.security.filter.JwtAuthenticationFilter;
@@ -88,8 +89,8 @@ public class SecurityConfig {
 //                .antMatchers("/api/v1/manager/**").hasRole("MANAGER")
                 .and()
                 .exceptionHandling()
-                .authenticationEntryPoint(new JwtNotAuthenticatedHandler())
-                .accessDeniedHandler(new JwtAccessDeniedHandler())
+                .authenticationEntryPoint(new JwtNotAuthenticatedHandler(new ObjectMapper()))
+                .accessDeniedHandler(new JwtAccessDeniedHandler(new ObjectMapper()))
                 .and();
     }
 }

--- a/src/main/java/com/knud4/an/exception/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/knud4/an/exception/handler/JwtAccessDeniedHandler.java
@@ -1,5 +1,11 @@
 package com.knud4.an.exception.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knud4.an.utils.api.ApiUtil;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
@@ -8,12 +14,21 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
     @Override
     public void handle(HttpServletRequest request,
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        logger.error("접근 권한이 없습니다.", accessDeniedException);
+        String body = objectMapper
+                .writeValueAsString(ApiUtil.error(HttpServletResponse.SC_UNAUTHORIZED, "접근 권한이 없습니다."));
 
-        response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(body);
     }
 }

--- a/src/main/java/com/knud4/an/exception/handler/JwtNotAuthenticatedHandler.java
+++ b/src/main/java/com/knud4/an/exception/handler/JwtNotAuthenticatedHandler.java
@@ -1,5 +1,11 @@
 package com.knud4.an.exception.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knud4.an.utils.api.ApiUtil;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -8,12 +14,21 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@RequiredArgsConstructor
 public class JwtNotAuthenticatedHandler implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException, ServletException {
-
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증 정보가 잘못되었습니다.");
+        logger.error("인증 정보가 잘못되었습니다.", authException);
+        String body = objectMapper
+                .writeValueAsString(ApiUtil.error(HttpServletResponse.SC_UNAUTHORIZED, "인증 정보가 잘못되었습니다."));
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(body);
     }
 }

--- a/src/main/java/com/knud4/an/logger/LoggingFilter.java
+++ b/src/main/java/com/knud4/an/logger/LoggingFilter.java
@@ -3,6 +3,7 @@ package com.knud4.an.logger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
@@ -19,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+@Order(1)
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
     protected static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);


### PR DESCRIPTION
## PR 요약

1. Security 예외 응답 로직 수정, Logging Filter 위치를 수정했습니다.

## 변경 사항

1. 서버 응답 스펙으로 Security 인증/인가 핸들러에서 응답을 구성했습니다.
2. Logging Filter 를 커스텀 필터 중 가장 앞에 위치시켰습니다.

## 참고 사항

1.
