### PR TITLE
Profile 삭제 기능(검토 사항 있음), JwtProfile Filter 에 profile 검증 로직 추가

### DIFF
--- a/src/main/java/com/knud4/an/account/controller/AccountController.java
+++ b/src/main/java/com/knud4/an/account/controller/AccountController.java
@@ -9,8 +9,7 @@ import com.knud4.an.utils.api.ApiUtil.*;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -32,9 +31,16 @@ public class AccountController {
     @Cacheable(key = "#req.getAttribute('profileId')", cacheNames = "profile")
     @Operation(summary = "내 프로필 조회")
     @GetMapping("/api/v1/profiles/me")
-    public ApiSuccessResult<ProfileDTO> myProfile(HttpServletRequest req) throws RuntimeException{
+    public ApiSuccessResult<ProfileDTO> myProfile(HttpServletRequest req) throws RuntimeException {
         Profile profile = accountService.findProfileById((Long)req.getAttribute("profileId"));
 
         return ApiUtil.success(new ProfileDTO(profile.getId(), profile.getName(), profile.getAge(), profile.getGender()));
+    }
+
+    @DeleteMapping("/api/v1/accounts/profiles/{id}")
+    public ApiSuccessResult<String> deleteProfile(@PathVariable(value = "id")Long profileId, HttpServletRequest req)
+            throws RuntimeException {
+        accountService.deleteProfile(profileId);
+        return ApiUtil.success("삭제 성공했습니다.");
     }
 }

--- a/src/main/java/com/knud4/an/account/entity/Profile.java
+++ b/src/main/java/com/knud4/an/account/entity/Profile.java
@@ -1,11 +1,15 @@
 package com.knud4.an.account.entity;
 
+import com.knud4.an.comment.entity.CommunityComment;
+import com.knud4.an.community.entity.Community;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -26,6 +30,12 @@ public class Profile {
     private String name;
     private Integer age;
     private String pin;
+
+    @OneToMany(mappedBy = "writer")
+    private List<CommunityComment> communityComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "writer")
+    private List<Community> communities = new ArrayList<>();
 
     @Builder
     public Profile(Account account, Gender gender, String name, Integer age, String pin) {

--- a/src/main/java/com/knud4/an/account/repository/AccountRepository.java
+++ b/src/main/java/com/knud4/an/account/repository/AccountRepository.java
@@ -76,10 +76,14 @@ public class AccountRepository {
 
     public boolean profileExistsByName(String profileName, Long accountId) {
         return em.createQuery("select count(p) > 0 from Profile p " +
-                "where p.name = :profileName " +
+                        "where p.name = :profileName " +
                         "and p.account.id = :accountId", Boolean.class)
                 .setParameter("profileName", profileName)
                 .setParameter("accountId", accountId)
                 .getSingleResult();
+    }
+
+    public void deleteProfile(Profile profile) {
+        em.remove(profile);
     }
 }

--- a/src/main/java/com/knud4/an/account/service/AccountService.java
+++ b/src/main/java/com/knud4/an/account/service/AccountService.java
@@ -3,6 +3,8 @@ package com.knud4.an.account.service;
 import com.knud4.an.account.entity.Account;
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.account.repository.AccountRepository;
+import com.knud4.an.comment.entity.CommunityComment;
+import com.knud4.an.community.entity.Community;
 import com.knud4.an.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -42,5 +44,17 @@ public class AccountService {
     public Profile findProfileByAccountIdAndProfileName(Long accountId, String profileName) {
         return accountRepository.findProfileByAccountIdAndProfileName(accountId, profileName)
                 .orElseThrow(() -> new NotFoundException("프로필이 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void deleteProfile(Long profileId) {
+        Profile profile = accountRepository.findProfileById(profileId);
+        if (profile == null) {
+            throw new NotFoundException("존재하지 않는 회원입니다.");
+        }
+
+        profile.getCommunities().forEach(Community::deleteWriter);
+        profile.getCommunityComments().forEach(CommunityComment::deleteWriter);
+        accountRepository.deleteProfile(profile);
     }
 }

--- a/src/main/java/com/knud4/an/comment/entity/CommunityComment.java
+++ b/src/main/java/com/knud4/an/comment/entity/CommunityComment.java
@@ -29,4 +29,7 @@ public class CommunityComment extends Comment {
         this.setWriter(writer);
     }
 
+    public void deleteWriter() {
+        this.setWriter(null);
+    }
 }

--- a/src/main/java/com/knud4/an/community/entity/Community.java
+++ b/src/main/java/com/knud4/an/community/entity/Community.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
 
 @Entity
 @Getter
@@ -47,5 +46,11 @@ public class Community extends Board {
 
     public void increaseLike() {
         this.likes++;
+    }
+
+    public void deleteWriter() {
+        this.setWriter(null);
+        this.writerHouseName = null;
+        this.writerLineName = null;
     }
 }

--- a/src/main/java/com/knud4/an/security/details/ProfileDetailsService.java
+++ b/src/main/java/com/knud4/an/security/details/ProfileDetailsService.java
@@ -1,0 +1,30 @@
+package com.knud4.an.security.details;
+
+import com.knud4.an.account.entity.Account;
+import com.knud4.an.account.entity.Profile;
+import com.knud4.an.account.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileDetailsService implements UserDetailsService {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String profileId) throws UsernameNotFoundException {
+        Profile profile = accountRepository.findProfileById(Long.parseLong(profileId));
+
+        if (profile == null) {
+            throw new UsernameNotFoundException("프로필이 존재하지 않습니다.");
+        }
+
+        Account account = accountRepository.findAccountById(profile.getAccount().getId());
+
+        return new AccountDetails(account);
+    }
+}

--- a/src/main/java/com/knud4/an/security/filter/JwtProfileAuthenticationFilter.java
+++ b/src/main/java/com/knud4/an/security/filter/JwtProfileAuthenticationFilter.java
@@ -35,8 +35,10 @@ public class JwtProfileAuthenticationFilter extends GenericFilterBean {
         if(token != null && !jwtProvider.isProfileTokenExpired(token)) {
             try {
                 String emailFromToken = jwtProvider.getEmailFromToken(token);
+                Long profileId = jwtProvider.getProfileIdFromToken(token);
+
                 authenticate = jwtProvider
-                        .authenticate(new UsernamePasswordAuthenticationToken(emailFromToken, ""));
+                        .authenticate(new UsernamePasswordAuthenticationToken(emailFromToken, profileId));
                 SecurityContextHolder.getContext().setAuthentication(authenticate);
             } catch(Exception e) {
             }

--- a/src/main/java/com/knud4/an/security/provider/JwtProvider.java
+++ b/src/main/java/com/knud4/an/security/provider/JwtProvider.java
@@ -10,7 +10,9 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.knud4.an.security.details.AccountDetails;
 import com.knud4.an.security.details.AccountDetailsService;
+import com.knud4.an.security.details.ProfileDetailsService;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -28,6 +30,7 @@ import java.util.Map;
 public class JwtProvider implements AuthenticationProvider {
 
     private final AccountDetailsService accountDetailsService;
+    private final ProfileDetailsService profileDetailsService;
 
     private static final long TOKEN_VALIDATION_SECOND = 1000L * 60 * 120;
     private static final long REFRESH_TOKEN_VALIDATION_TIME = 1000L * 60 * 60 * 48;
@@ -226,9 +229,15 @@ public class JwtProvider implements AuthenticationProvider {
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-        AccountDetails userDetails = (AccountDetails) accountDetailsService.loadUserByUsername
-                ((String) authentication.getPrincipal());
+        AccountDetails userDetails;
 
+        if (authentication.getCredentials().equals(Strings.EMPTY)) {
+             userDetails = (AccountDetails) accountDetailsService
+                     .loadUserByUsername((String) authentication.getPrincipal());
+        } else {
+            userDetails = (AccountDetails) profileDetailsService
+                    .loadUserByUsername(authentication.getCredentials().toString());
+        }
 
         return new UsernamePasswordAuthenticationToken(
                 userDetails.getEmail(),


### PR DESCRIPTION
## PR 요약

1. Profile 삭제 기능, JwtProfile Filter 에 profile 검증 로직 추가

## 변경 사항

1. Profile 삭제 기능을 추가하였습니다.
2. 기존 AccountDetailService 에서 Profile 검증 로직을 추가한 ProfileDetailService 를 추가합니다.

## 참고 사항

1. Profile 삭제 시 ToOne 연관관계에 있는 Community, Comment 에 존재하는 Profile 필드도 null 로 처리했습니다.
2. 추 후 Community, Comment 호출 시 Writer 를 탐색하는 과정에서 오류가 발생할 수 있기 때문에 여러가지 방안 중 합의가 필요합니다.
2-1. 프로필 삭제 시 모든 Community, Comment 삭제
2-2. 가짜 회원으로 변경(탈퇴한 프로필)
2-3. 글의 상태 추가

등등...
