### PR TITLE
Feat: Community, Notice api response 데이터 수정

### DIFF
--- a/src/main/java/com/knud4/an/community/controller/CommunityController.java
+++ b/src/main/java/com/knud4/an/community/controller/CommunityController.java
@@ -3,7 +3,6 @@ package com.knud4.an.community.controller;
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.account.service.AccountService;
 import com.knud4.an.board.Range;
-import com.knud4.an.comment.service.CommunityCommentService;
 import com.knud4.an.community.dto.CommunityDTO;
 import com.knud4.an.community.dto.CommunityListDTO;
 import com.knud4.an.community.dto.CreateCommunityForm;
@@ -57,7 +56,9 @@ public class CommunityController {
             else
                 communityDTOList = CommunityDTO.entityListToDTOList(communityService.findByCategory(category, page, count, accountId));
         }
-        return ApiUtil.success(new CommunityListDTO(communityService.isLastPage(page, count), communityDTOList));
+        return ApiUtil.success(new CommunityListDTO(communityService.isFirstPage(page),
+                communityService.isLastPage(page, count),
+                communityDTOList));
     }
 
     @Operation(summary = "내 커뮤니티글 전체 조회")
@@ -66,8 +67,9 @@ public class CommunityController {
                                                                     @RequestParam(name = "count") int count,
                                                                     HttpServletRequest req) {
         Long profileId = (Long) req.getAttribute("profileId");
-        return ApiUtil.success(new CommunityListDTO(communityService.isLastPage(page, count),
-                        CommunityDTO.entityListToDTOList(communityService.findAllMine(page, count, profileId))));
+        return ApiUtil.success(new CommunityListDTO(communityService.isFirstPage(page),
+                communityService.isLastPage(page, count),
+                CommunityDTO.entityListToDTOList(communityService.findAllMine(page, count, profileId))));
     }
 
     @Operation(summary = "커뮤니티글 상세 조회 (id)")

--- a/src/main/java/com/knud4/an/community/dto/CommunityDTO.java
+++ b/src/main/java/com/knud4/an/community/dto/CommunityDTO.java
@@ -1,5 +1,6 @@
 package com.knud4.an.community.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.knud4.an.board.Range;
 import com.knud4.an.community.entity.Category;
 import com.knud4.an.community.entity.Community;
@@ -7,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 public class CommunityDTO {
 
-    private Long community_id;
+    private Long id;
 
     private String title;
 
@@ -25,23 +27,22 @@ public class CommunityDTO {
 
     private Range range;
 
-    private String writerLineName;
+    private Writer writer;
 
-    private String writerHouseName;
-
-    private String writerName;
+    private LocalDateTime createdDate;
 
     private Long like;
 
     public CommunityDTO(Community community) {
-        this.community_id = community.getId();
+        this.id = community.getId();
         this.title = community.getTitle();
         this.content = community.getContent();
         this.category = community.getCategory();
         this.range = community.getRange();
-        this.writerLineName = community.getWriterLineName();
-        this.writerHouseName = community.getWriterHouseName();
-        this.writerName = community.getWriter().getName();
+        this.writer = new Writer(community.getWriter().getName(),
+                community.getWriterLineName(),
+                community.getWriterHouseName());
+        this.createdDate = community.getCreatedDate();
         this.like = community.getLikes();
     }
 
@@ -49,5 +50,11 @@ public class CommunityDTO {
         List<CommunityDTO> communityDTOList = new ArrayList<>();
         for(Community community : communities) communityDTOList.add(new CommunityDTO(community));
         return communityDTOList;
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class Writer {
+        String name, lineName, houseName;
     }
 }

--- a/src/main/java/com/knud4/an/community/dto/CommunityListDTO.java
+++ b/src/main/java/com/knud4/an/community/dto/CommunityListDTO.java
@@ -2,15 +2,15 @@ package com.knud4.an.community.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
 public class CommunityListDTO {
 
-    private boolean isLastPage;
-    private List<CommunityDTO> communityList;
+    @NotNull private Boolean isFirstPage;
+    @NotNull private Boolean isLastPage;
+    @NotNull private List<CommunityDTO> list;
 }

--- a/src/main/java/com/knud4/an/community/service/CommunityService.java
+++ b/src/main/java/com/knud4/an/community/service/CommunityService.java
@@ -89,7 +89,11 @@ public class CommunityService {
         return communityRepository.findAllMine(profileId, page, count);
     }
 
-    public boolean isLastPage(int page, int count) {
+    public Boolean isFirstPage(int page) {
+        return page == 1;
+    }
+
+    public Boolean isLastPage(int page, int count) {
         Long communityCnt = communityRepository.findCommunityCount();
         return (long) (page + 2) * count >= communityCnt;
     }

--- a/src/main/java/com/knud4/an/notice/controller/NoticeController.java
+++ b/src/main/java/com/knud4/an/notice/controller/NoticeController.java
@@ -6,6 +6,8 @@ import com.knud4.an.account.service.AccountService;
 import com.knud4.an.board.Range;
 import com.knud4.an.notice.dto.CreateNoticeForm;
 import com.knud4.an.notice.dto.NoticeDTO;
+import com.knud4.an.notice.dto.NoticeListDTO;
+import com.knud4.an.notice.entity.Notice;
 import com.knud4.an.notice.service.NoticeService;
 import com.knud4.an.utils.api.ApiUtil;
 import com.knud4.an.utils.api.ApiUtil.*;
@@ -37,14 +39,18 @@ public class NoticeController {
 
     @Operation(summary = "공지사항 전체 조회")
     @GetMapping("/api/v1/notices")
-    public ApiSuccessResult<List<NoticeDTO>> findAll(@RequestParam(name = "page") int page,
-                                                     @RequestParam(name = "count") int count,
-                                                     @RequestParam(name = "range") Range range,
-                                                     HttpServletRequest req) {
+    public ApiSuccessResult<NoticeListDTO> findAll(@RequestParam(name = "page") int page,
+                                                   @RequestParam(name = "count") int count,
+                                                   @RequestParam(name = "range") Range range,
+                                                   HttpServletRequest req) {
         Long accountId = (Long) req.getAttribute("accountId");
+        List<Notice> noticeList;
         if(range.equals(Range.LINE))
-            return ApiUtil.success(NoticeDTO.entityListToDTOList(noticeService.findAllMyLine(page, count, accountId)));
-        return ApiUtil.success(NoticeDTO.entityListToDTOList(noticeService.findAll(page, count, accountId)));
+            noticeList = noticeService.findAllMyLine(page, count, accountId);
+        else noticeList = noticeService.findAll(page, count, accountId);
+        return ApiUtil.success(new NoticeListDTO(noticeService.isFirstPage(page),
+                noticeService.isLastPage(page, count),
+                NoticeDTO.entityListToDTOList(noticeList)));
     }
 
     @Operation(summary = "공지사항 상세 조회 (id)")

--- a/src/main/java/com/knud4/an/notice/dto/NoticeDTO.java
+++ b/src/main/java/com/knud4/an/notice/dto/NoticeDTO.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 public class NoticeDTO {
 
-    private Long noticeId;
+    private Long id;
 
     private String title;
 
@@ -32,7 +32,7 @@ public class NoticeDTO {
     private String releaseLine;
 
     public NoticeDTO(Notice notice) {
-        this.noticeId = notice.getId();
+        this.id = notice.getId();
         this.title = notice.getTitle();
         this.content = notice.getContent();
         this.expiredDate = notice.getExpiredDate();

--- a/src/main/java/com/knud4/an/notice/dto/NoticeListDTO.java
+++ b/src/main/java/com/knud4/an/notice/dto/NoticeListDTO.java
@@ -1,0 +1,16 @@
+package com.knud4.an.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class NoticeListDTO {
+
+    @NotNull private Boolean isFirstPage;
+    @NotNull private Boolean isLastPage;
+    @NotNull private List<NoticeDTO> list;
+}

--- a/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
@@ -73,6 +73,11 @@ public class NoticeRepository {
                 .getResultList();
     }
 
+    public Long findNoticeCount() {
+        return em.createQuery("select count(n) from Notice n", Long.class)
+                .getSingleResult();
+    }
+
     public void delete(Notice notice) {
         em.remove(notice);
     }

--- a/src/main/java/com/knud4/an/notice/service/NoticeService.java
+++ b/src/main/java/com/knud4/an/notice/service/NoticeService.java
@@ -87,4 +87,13 @@ public class NoticeService {
             throw new NotAuthenticatedException("삭제 권한이 없습니다.");
         noticeRepository.delete(notice);
     }
+
+    public Boolean isFirstPage(int page) {
+        return page == 1;
+    }
+
+    public Boolean isLastPage(int page, int count) {
+        Long noticeCnt = noticeRepository.findNoticeCount();
+        return (long) (page + 2) * count >= noticeCnt;
+    }
 }


### PR DESCRIPTION
## PR 요약

1. Community, Notice api response 데이터 수정합니다.

## 변경 사항

1. CommunityListDTO isFirstPage 추가
2. CommunityDTO writer 객체 추가
3. NoticeListDTO 추가

## 참고 사항

1. 프론트에서 Community, Notice, Report api response format 통일을 요청해서 공용 클래스 구축을 고려했지만 우선은 보류합니다.
