### PR TITLE
Feat: Community, Notice, Comment 응답 로직 수정

### DIFF
--- a/src/main/java/com/knud4/an/board/Board.java
+++ b/src/main/java/com/knud4/an/board/Board.java
@@ -1,7 +1,6 @@
 package com.knud4.an.board;
 
 import com.knud4.an.Base.BaseEntity;
-import com.knud4.an.account.entity.Account;
 import com.knud4.an.account.entity.Profile;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +22,8 @@ public abstract class Board extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Profile writer;
 
-    private Range range;
+    @Enumerated(EnumType.STRING)
+    private Scope scope;
 
     protected void setTitle(String title) {
         this.title = title;
@@ -35,8 +35,8 @@ public abstract class Board extends BaseEntity {
 
     protected void setWriter(Profile writer) {this.writer = writer;}
 
-    protected void setRange(Range range) {
-        this.range = range;
+    protected void setScope(Scope scope) {
+        this.scope = scope;
     }
 
     public void changeTitle(String title) {
@@ -47,7 +47,7 @@ public abstract class Board extends BaseEntity {
         this.content = content;
     }
 
-    public void changeRange(Range range) {
-        this.range = range;
+    public void changeScope(Scope scope) {
+        this.scope = scope;
     }
 }

--- a/src/main/java/com/knud4/an/board/Scope.java
+++ b/src/main/java/com/knud4/an/board/Scope.java
@@ -1,5 +1,5 @@
 package com.knud4.an.board;
 
-public enum Range {
+public enum Scope {
     ALL, LINE
 }

--- a/src/main/java/com/knud4/an/comment/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/knud4/an/comment/repository/CommunityCommentRepository.java
@@ -23,13 +23,13 @@ public class CommunityCommentRepository {
     }
 
     public List<CommunityComment> findAllByCommunityId(Long communityId) {
-        return em.createQuery("select c from CommunityComment c where c.community.id = :communityId", CommunityComment.class)
+        return em.createQuery("select c from CommunityComment c where c.community.id = :communityId order by c.id desc", CommunityComment.class)
                 .setParameter("communityId", communityId)
                 .getResultList();
     }
 
     public List<CommunityComment> findAllByCommunityId(Long communityId, int page, int count) {
-        return em.createQuery("select c from CommunityComment c where c.community.id = :communityId", CommunityComment.class)
+        return em.createQuery("select c from CommunityComment c where c.community.id = :communityId order by c.id desc", CommunityComment.class)
                 .setParameter("communityId", communityId)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)

--- a/src/main/java/com/knud4/an/comment/repository/ReportCommentRepository.java
+++ b/src/main/java/com/knud4/an/comment/repository/ReportCommentRepository.java
@@ -23,13 +23,13 @@ public class ReportCommentRepository {
     }
 
     public List<ReportComment> findAllByReportId(Long reportId) {
-        return em.createQuery("select r from ReportComment r where r.report.id = :reportId", ReportComment.class)
+        return em.createQuery("select r from ReportComment r where r.report.id = :reportId order by r.id desc", ReportComment.class)
                 .setParameter("reportId", reportId)
                 .getResultList();
     }
 
     public List<ReportComment> findAllByReportId(Long reportId, int page, int count) {
-        return em.createQuery("select r from ReportComment r where r.report.id = :reportId", ReportComment.class)
+        return em.createQuery("select r from ReportComment r where r.report.id = :reportId order by r.id desc", ReportComment.class)
                 .setParameter("reportId", reportId)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)

--- a/src/main/java/com/knud4/an/community/controller/CommunityController.java
+++ b/src/main/java/com/knud4/an/community/controller/CommunityController.java
@@ -7,6 +7,7 @@ import com.knud4.an.community.dto.CommunityDTO;
 import com.knud4.an.community.dto.CommunityListDTO;
 import com.knud4.an.community.dto.CreateCommunityForm;
 import com.knud4.an.community.entity.Category;
+import com.knud4.an.community.entity.Community;
 import com.knud4.an.community.service.CommunityService;
 import com.knud4.an.annotation.AccountRequired;
 import com.knud4.an.annotation.ProfileRequired;
@@ -85,7 +86,10 @@ public class CommunityController {
     public ApiSuccessResult<CommunityDTO> findById(@PathVariable(name = "id") Long id,
                                                    HttpServletRequest req) {
         Long accountId = (Long) req.getAttribute("accountId");
-        return ApiUtil.success(new CommunityDTO(communityService.findCommunityById(id, accountId)));
+        Community community = communityService.findCommunityById(id, accountId);
+        CommunityDTO communityDTO = new CommunityDTO(community);
+        communityDTO.setIsMine(communityService.isMine(community, accountId));
+        return ApiUtil.success(communityDTO);
     }
 
     @ProfileRequired

--- a/src/main/java/com/knud4/an/community/controller/CommunityController.java
+++ b/src/main/java/com/knud4/an/community/controller/CommunityController.java
@@ -2,7 +2,7 @@ package com.knud4.an.community.controller;
 
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.account.service.AccountService;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.community.dto.CommunityDTO;
 import com.knud4.an.community.dto.CommunityListDTO;
 import com.knud4.an.community.dto.CreateCommunityForm;
@@ -47,18 +47,18 @@ public class CommunityController {
     @GetMapping("/api/v1/communities")
     public ApiUtil.ApiSuccessResult<CommunityListDTO> findAll(@RequestParam(name = "page") int page,
                                                               @RequestParam(name = "count") int count,
-                                                              @RequestParam(name = "range") Range range,
+                                                              @RequestParam(name = "scope") Scope scope,
                                                               @RequestParam(name = "category") Category category,
                                                               HttpServletRequest req) {
         Long accountId = (Long) req.getAttribute("accountId");
         List<CommunityDTO> communityDTOList;
         if (category.equals(Category.ALL)) {
-            if (range.equals(Range.LINE))
+            if (scope.equals(Scope.LINE))
                 communityDTOList = CommunityDTO.entityListToDTOList(communityService.findAllMyLine(page, count, accountId));
             else
                 communityDTOList = CommunityDTO.entityListToDTOList(communityService.findAll(page, count, accountId));
         } else {
-            if (range.equals(Range.LINE))
+            if (scope.equals(Scope.LINE))
                 communityDTOList = CommunityDTO.entityListToDTOList(communityService.findMyLineByCategory(category, page, count, accountId));
             else
                 communityDTOList = CommunityDTO.entityListToDTOList(communityService.findByCategory(category, page, count, accountId));

--- a/src/main/java/com/knud4/an/community/dto/CommunityDTO.java
+++ b/src/main/java/com/knud4/an/community/dto/CommunityDTO.java
@@ -33,13 +33,17 @@ public class CommunityDTO {
 
     private Long like;
 
+
+    private Boolean isMine;
+
     public CommunityDTO(Community community) {
         this.id = community.getId();
         this.title = community.getTitle();
         this.content = community.getContent();
         this.category = community.getCategory();
         this.range = community.getRange();
-        this.writer = new Writer(community.getWriter().getName(),
+        this.writer = new Writer(community.getWriter().getId(),
+                community.getWriter().getName(),
                 community.getWriterLineName(),
                 community.getWriterHouseName());
         this.createdDate = community.getCreatedDate();
@@ -55,6 +59,7 @@ public class CommunityDTO {
     @Data
     @AllArgsConstructor
     private static class Writer {
+        Long id;
         String name, lineName, houseName;
     }
 }

--- a/src/main/java/com/knud4/an/community/dto/CommunityDTO.java
+++ b/src/main/java/com/knud4/an/community/dto/CommunityDTO.java
@@ -1,7 +1,6 @@
 package com.knud4.an.community.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.community.entity.Category;
 import com.knud4.an.community.entity.Community;
 import lombok.AllArgsConstructor;
@@ -25,7 +24,7 @@ public class CommunityDTO {
 
     private Category category;
 
-    private Range range;
+    private Scope scope;
 
     private Writer writer;
 
@@ -41,13 +40,13 @@ public class CommunityDTO {
         this.title = community.getTitle();
         this.content = community.getContent();
         this.category = community.getCategory();
-        this.range = community.getRange();
+        this.scope = community.getScope();
         this.writer = new Writer(community.getWriter().getId(),
                 community.getWriter().getName(),
                 community.getWriterLineName(),
                 community.getWriterHouseName());
         this.createdDate = community.getCreatedDate();
-        this.like = community.getLikes();
+        this.like = community.getLike();
     }
 
     public static List<CommunityDTO> entityListToDTOList(List<Community> communities) {

--- a/src/main/java/com/knud4/an/community/dto/CreateCommunityForm.java
+++ b/src/main/java/com/knud4/an/community/dto/CreateCommunityForm.java
@@ -1,7 +1,7 @@
 package com.knud4.an.community.dto;
 
 import com.knud4.an.community.entity.Category;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,6 +23,6 @@ public class CreateCommunityForm {
     private Category category;
 
     @NotNull
-    private Range range;
+    private Scope scope;
 
 }

--- a/src/main/java/com/knud4/an/community/entity/Community.java
+++ b/src/main/java/com/knud4/an/community/entity/Community.java
@@ -3,23 +3,27 @@ package com.knud4.an.community.entity;
 import com.knud4.an.account.entity.Account;
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.board.Board;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Community extends Board {
 
+    @Enumerated(EnumType.STRING)
     private Category category;
 
-    private Long likes;
+    @Column(name = "likes")
+    private Long like;
 
     private String writerLineName;
 
@@ -28,14 +32,14 @@ public class Community extends Board {
 
     @Builder
     public Community(String title, String content, Profile writer,
-                     Category category, Long likes, Range range) {
+                     Category category, Long like, Scope scope) {
         this.setContent(content);
         this.setTitle(title);
         this.setWriter(writer);
-        this.setRange(range);
+        this.setScope(scope);
 
         this.category = category;
-        this.likes = likes;
+        this.like = like;
         Account account = writer.getAccount();
         this.writerLineName = account.getLine().getName();
         this.writerHouseName = account.getHouse().getName();
@@ -46,6 +50,6 @@ public class Community extends Board {
     }
 
     public void increaseLike() {
-        this.likes++;
+        this.like++;
     }
 }

--- a/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
+++ b/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
@@ -25,75 +25,93 @@ public class CommunityRepository {
         return Optional.ofNullable(em.find(Community.class, id));
     }
 
-    public List<Community> findAll(int page, int count) {
-        return em.createQuery("select c from Community c order by c.id desc", Community.class)
+    public List<Community> findAll(int page, int count, boolean desc) {
+        String query = "select c from Community c order by c.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findByLine(String lineName, int page, int count) {
-        return em.createQuery("select c from Community c where c.writerLineName = :lineName order by c.id desc", Community.class)
+    public List<Community> findByLine(String lineName, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.writerLineName = :lineName order by c.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
                 .setParameter("lineName", lineName)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findAllMine(Long profileId, int page, int count) {
-        return em.createQuery("select c from Community c where c.writer.id = :profileId", Community.class)
+    public List<Community> findAllMine(Long profileId, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.writer.id = :profileId";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
                 .setParameter("profileId", profileId)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findByScope(Scope scope, int page, int count) {
-        return em.createQuery("select c from Community c where c.scope = :scope order by c.id desc", Community.class)
+    public List<Community> findByScope(Scope scope, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.scope = :scope order by c.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
                 .setParameter("scope", scope)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findByScopeAndLine(Scope scope, String lineName, int page, int count) {
-        return em.createQuery("select c from Community c where c.scope = :scope and c.writerLineName = :lineName order by c.id desc", Community.class)
-                .setParameter("scope", scope)
-                .setParameter("lineName", lineName)
-                .setFirstResult((page-1)*count)
-                .setMaxResults(count)
-                .getResultList();
-    }
-
-    public List<Community> findByCategory(Category category, int page, int count) {
-        return em.createQuery("select c from Community c where c.category = :category order by c.id desc", Community.class)
-                .setParameter("category", category)
-                .setFirstResult((page-1)*count)
-                .setMaxResults(count)
-                .getResultList();
-    }
-
-    public List<Community> findByScopeAndCategory(Scope scope, Category category, int page, int count) {
-        return em.createQuery("select c from Community c where c.scope = :scope and c.category = :category order by c.id desc", Community.class)
-                .setParameter("scope", scope)
-                .setParameter("category", category)
-                .setFirstResult((page-1)*count)
-                .setMaxResults(count)
-                .getResultList();
-    }
-
-    public List<Community> findByScopeAndLineAndCategory(Scope scope, String lineName, Category category, int page, int count) {
-        return em.createQuery("select c from Community c where c.scope = :scope and c.writerLineName = :lineName and c.category = :category order by c.id desc", Community.class)
+    public List<Community> findByScopeAndLine(Scope scope, String lineName, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.scope = :scope and c.writerLineName = :lineName order by c.id desc";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
                 .setParameter("scope", scope)
                 .setParameter("lineName", lineName)
+                .setFirstResult((page-1)*count)
+                .setMaxResults(count)
+                .getResultList();
+    }
+
+    public List<Community> findByCategory(Category category, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.category = :category order by c.id";
+        query += " desc";
+        return em.createQuery(query, Community.class)
                 .setParameter("category", category)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findByLineAndCategory(String lineName, Category category, int page, int count) {
-        return em.createQuery("select c from Community c where c.writerLineName = :lineName and c.category = :category order by c.id desc", Community.class)
+    public List<Community> findByScopeAndCategory(Scope scope, Category category, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.scope = :scope and c.category = :category order by c.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
+                .setParameter("scope", scope)
+                .setParameter("category", category)
+                .setFirstResult((page-1)*count)
+                .setMaxResults(count)
+                .getResultList();
+    }
+
+    public List<Community> findByScopeAndLineAndCategory(Scope scope, String lineName, Category category, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.scope = :scope and c.writerLineName = :lineName and c.category = :category order by c.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
+                .setParameter("scope", scope)
+                .setParameter("lineName", lineName)
+                .setParameter("category", category)
+                .setFirstResult((page-1)*count)
+                .setMaxResults(count)
+                .getResultList();
+    }
+
+    public List<Community> findByLineAndCategory(String lineName, Category category, int page, int count, boolean desc) {
+        String query = "select c from Community c where c.writerLineName = :lineName and c.category = :category order by c.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Community.class)
                 .setParameter("lineName", lineName)
                 .setParameter("category", category)
                 .setFirstResult((page-1)*count)

--- a/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
+++ b/src/main/java/com/knud4/an/community/repository/CommunityRepository.java
@@ -1,6 +1,6 @@
 package com.knud4.an.community.repository;
 
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.community.entity.Category;
 import com.knud4.an.community.entity.Community;
 import lombok.RequiredArgsConstructor;
@@ -48,17 +48,17 @@ public class CommunityRepository {
                 .getResultList();
     }
 
-    public List<Community> findByRange(Range range, int page, int count) {
-        return em.createQuery("select c from Community c where c.range = :range order by c.id desc", Community.class)
-                .setParameter("range", range)
+    public List<Community> findByScope(Scope scope, int page, int count) {
+        return em.createQuery("select c from Community c where c.scope = :scope order by c.id desc", Community.class)
+                .setParameter("scope", scope)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findByRangeAndLine(Range range, String lineName, int page, int count) {
-        return em.createQuery("select c from Community c where c.range = :range and c.writerLineName = :lineName order by c.id desc", Community.class)
-                .setParameter("range", range)
+    public List<Community> findByScopeAndLine(Scope scope, String lineName, int page, int count) {
+        return em.createQuery("select c from Community c where c.scope = :scope and c.writerLineName = :lineName order by c.id desc", Community.class)
+                .setParameter("scope", scope)
                 .setParameter("lineName", lineName)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
@@ -73,18 +73,18 @@ public class CommunityRepository {
                 .getResultList();
     }
 
-    public List<Community> findByRangeAndCategory(Range range, Category category, int page, int count) {
-        return em.createQuery("select c from Community c where c.range = :range and c.category = :category order by c.id desc", Community.class)
-                .setParameter("range", range)
+    public List<Community> findByScopeAndCategory(Scope scope, Category category, int page, int count) {
+        return em.createQuery("select c from Community c where c.scope = :scope and c.category = :category order by c.id desc", Community.class)
+                .setParameter("scope", scope)
                 .setParameter("category", category)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Community> findByRangeAndLineAndCategory(Range range, String lineName, Category category, int page, int count) {
-        return em.createQuery("select c from Community c where c.range = :range and c.writerLineName = :lineName and c.category = :category order by c.id desc", Community.class)
-                .setParameter("range", range)
+    public List<Community> findByScopeAndLineAndCategory(Scope scope, String lineName, Category category, int page, int count) {
+        return em.createQuery("select c from Community c where c.scope = :scope and c.writerLineName = :lineName and c.category = :category order by c.id desc", Community.class)
+                .setParameter("scope", scope)
                 .setParameter("lineName", lineName)
                 .setParameter("category", category)
                 .setFirstResult((page-1)*count)

--- a/src/main/java/com/knud4/an/community/service/CommunityService.java
+++ b/src/main/java/com/knud4/an/community/service/CommunityService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -131,5 +132,9 @@ public class CommunityService {
         List<CommunityComment> comments = commentRepository.findAllByCommunityId(id);
         for(CommunityComment comment : comments) commentRepository.delete(comment);
         communityRepository.delete(community);
+    }
+
+    public Boolean isMine(Community community, Long accountId) {
+        return Objects.equals(community.getWriter().getAccount().getId(), accountId);
     }
 }

--- a/src/main/java/com/knud4/an/community/service/CommunityService.java
+++ b/src/main/java/com/knud4/an/community/service/CommunityService.java
@@ -10,7 +10,7 @@ import com.knud4.an.community.dto.CommunityDTO;
 import com.knud4.an.community.dto.CreateCommunityForm;
 import com.knud4.an.community.entity.Category;
 import com.knud4.an.community.entity.Community;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.community.repository.CommunityRepository;
 import com.knud4.an.exception.NotAuthenticatedException;
 import com.knud4.an.exception.NotFoundException;
@@ -39,8 +39,8 @@ public class CommunityService {
                 .title(form.getTitle())
                 .content(form.getContent())
                 .category(form.getCategory())
-                .range(form.getRange())
-                .likes(0L)
+                .scope(form.getScope())
+                .like(0L)
                 .build();
         communityRepository.save(community);
         return community.getId();
@@ -49,7 +49,7 @@ public class CommunityService {
     public Community findCommunityById(Long communityId, Long accountId) {
         Community findCommunity = communityRepository.findById(communityId)
                 .orElseThrow(() -> new NotFoundException("커뮤니티글을 찾을 수 없습니다."));
-        if(findCommunity.getRange() == Range.LINE) {
+        if(findCommunity.getScope() == Scope.LINE) {
             Account account = accountRepository.findAccountById(accountId);
             if(!findCommunity.getWriterLineName().equals(account.getLine().getName())) {
                 throw new NotAuthenticatedException("접근 권한이 없습니다.");
@@ -61,8 +61,8 @@ public class CommunityService {
     public List<Community> findAll(int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
         if(account.getRole() == Role.ROLE_MANAGER) return communityRepository.findAll(page, count);
-        List<Community> findCommunities = communityRepository.findByRange(Range.ALL, page, count);
-        findCommunities.addAll(communityRepository.findByRangeAndLine(Range.LINE, account.getLine().getName(), page, count));
+        List<Community> findCommunities = communityRepository.findByScope(Scope.ALL, page, count);
+        findCommunities.addAll(communityRepository.findByScopeAndLine(Scope.LINE, account.getLine().getName(), page, count));
         return findCommunities;
     }
 
@@ -76,8 +76,8 @@ public class CommunityService {
         if(account.getRole().equals(Role.ROLE_MANAGER)) {
             return communityRepository.findByCategory(category, page, count);
         }
-        List<Community> findCommunities = communityRepository.findByRangeAndCategory(Range.ALL, category, page, count);
-        findCommunities.addAll(communityRepository.findByRangeAndLineAndCategory(Range.LINE, account.getLine().getName(), category, page, count));
+        List<Community> findCommunities = communityRepository.findByScopeAndCategory(Scope.ALL, category, page, count);
+        findCommunities.addAll(communityRepository.findByScopeAndLineAndCategory(Scope.LINE, account.getLine().getName(), category, page, count));
         return findCommunities;
     }
 
@@ -108,7 +108,7 @@ public class CommunityService {
         community.changeTitle(communityDTO.getTitle());
         community.changeContent(communityDTO.getContent());
         community.changeCategory(communityDTO.getCategory());
-        community.changeRange(communityDTO.getRange());
+        community.changeScope(communityDTO.getScope());
     }
 
     @Transactional

--- a/src/main/java/com/knud4/an/community/service/CommunityService.java
+++ b/src/main/java/com/knud4/an/community/service/CommunityService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -60,34 +61,36 @@ public class CommunityService {
 
     public List<Community> findAll(int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
-        if(account.getRole() == Role.ROLE_MANAGER) return communityRepository.findAll(page, count);
-        List<Community> findCommunities = communityRepository.findByScope(Scope.ALL, page, count);
-        findCommunities.addAll(communityRepository.findByScopeAndLine(Scope.LINE, account.getLine().getName(), page, count));
+        if(account.getRole() == Role.ROLE_MANAGER) return communityRepository.findAll(page, count, true);
+        List<Community> findCommunities = communityRepository.findByScope(Scope.ALL, page, count, false);
+        findCommunities.addAll(communityRepository.findByScopeAndLine(Scope.LINE, account.getLine().getName(), page, count, false));
+        findCommunities.sort((o1, o2) -> Long.compare(o2.getId(), o1.getId()));
         return findCommunities;
     }
 
     public List<Community> findAllMyLine(int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
-        return communityRepository.findByLine(account.getLine().getName(), page, count);
+        return communityRepository.findByLine(account.getLine().getName(), page, count, false);
     }
 
     public List<Community> findByCategory(Category category, int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
         if(account.getRole().equals(Role.ROLE_MANAGER)) {
-            return communityRepository.findByCategory(category, page, count);
+            return communityRepository.findByCategory(category, page, count, true);
         }
-        List<Community> findCommunities = communityRepository.findByScopeAndCategory(Scope.ALL, category, page, count);
-        findCommunities.addAll(communityRepository.findByScopeAndLineAndCategory(Scope.LINE, account.getLine().getName(), category, page, count));
+        List<Community> findCommunities = communityRepository.findByScopeAndCategory(Scope.ALL, category, page, count, false);
+        findCommunities.addAll(communityRepository.findByScopeAndLineAndCategory(Scope.LINE, account.getLine().getName(), category, page, count, false));
+        findCommunities.sort((o1, o2) -> Long.compare(o2.getId(), o1.getId()));
         return findCommunities;
     }
 
     public List<Community> findMyLineByCategory(Category category, int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
-        return communityRepository.findByLineAndCategory(account.getLine().getName(), category, page, count);
+        return communityRepository.findByLineAndCategory(account.getLine().getName(), category, page, count, true);
     }
 
     public List<Community> findAllMine(int page, int count, Long profileId) {
-        return communityRepository.findAllMine(profileId, page, count);
+        return communityRepository.findAllMine(profileId, page, count, true);
     }
 
     public Boolean isFirstPage(int page) {

--- a/src/main/java/com/knud4/an/notice/controller/NoticeController.java
+++ b/src/main/java/com/knud4/an/notice/controller/NoticeController.java
@@ -2,7 +2,7 @@ package com.knud4.an.notice.controller;
 
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.account.service.AccountService;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.annotation.AccountRequired;
 import com.knud4.an.annotation.ProfileRequired;
 import com.knud4.an.notice.dto.CreateNoticeForm;
@@ -46,11 +46,11 @@ public class NoticeController {
     @GetMapping("/api/v1/notices")
     public ApiSuccessResult<NoticeListDTO> findAll(@RequestParam(name = "page") int page,
                                                    @RequestParam(name = "count") int count,
-                                                   @RequestParam(name = "range") Range range,
+                                                   @RequestParam(name = "scope") Scope scope,
                                                    HttpServletRequest req) {
         Long accountId = (Long) req.getAttribute("accountId");
         List<Notice> noticeList;
-        if(range.equals(Range.LINE))
+        if(scope.equals(Scope.LINE))
             noticeList = noticeService.findAllMyLine(page, count, accountId);
         else noticeList = noticeService.findAll(page, count, accountId);
         return ApiUtil.success(new NoticeListDTO(noticeService.isFirstPage(page),

--- a/src/main/java/com/knud4/an/notice/controller/NoticeController.java
+++ b/src/main/java/com/knud4/an/notice/controller/NoticeController.java
@@ -64,7 +64,10 @@ public class NoticeController {
     public ApiSuccessResult<NoticeDTO> findById(@PathVariable(name = "id") Long id,
                                                 HttpServletRequest req) {
         Long accountId = (Long) req.getAttribute("accountId");
-        return ApiUtil.success(new NoticeDTO(noticeService.findNoticeById(id, accountId)));
+        Notice notice = noticeService.findNoticeById(id, accountId);
+        NoticeDTO noticeDTO = new NoticeDTO(notice);
+        noticeDTO.setIsMine(noticeService.isMine(notice, accountId));
+        return ApiUtil.success(new NoticeDTO());
     }
 
     @Operation(summary = "공지사항 수정")

--- a/src/main/java/com/knud4/an/notice/dto/CreateNoticeForm.java
+++ b/src/main/java/com/knud4/an/notice/dto/CreateNoticeForm.java
@@ -1,6 +1,6 @@
 package com.knud4.an.notice.dto;
 
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,7 +23,7 @@ public class CreateNoticeForm {
     private LocalDateTime expiredDate;
 
     @NotNull
-    private Range range;
+    private Scope scope;
 
     private String releaseLine;
 }

--- a/src/main/java/com/knud4/an/notice/dto/NoticeDTO.java
+++ b/src/main/java/com/knud4/an/notice/dto/NoticeDTO.java
@@ -1,6 +1,6 @@
 package com.knud4.an.notice.dto;
 
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.notice.entity.Notice;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -23,13 +23,14 @@ public class NoticeDTO {
 
     private LocalDateTime expiredDate;
 
-    private Range range;
+    private Scope scope;
 
     private LocalDateTime createdDate;
 
     private Writer writer;
 
     private String releaseLine;
+
 
     private Boolean isMine;
 
@@ -38,7 +39,7 @@ public class NoticeDTO {
         this.title = notice.getTitle();
         this.content = notice.getContent();
         this.expiredDate = notice.getExpiredDate();
-        this.range = notice.getRange();
+        this.scope = notice.getScope();
         this.createdDate = notice.getCreatedDate();
         this.releaseLine = notice.getReleaseLine();
         this.writer = new Writer(notice.getWriter().getId(),

--- a/src/main/java/com/knud4/an/notice/dto/NoticeDTO.java
+++ b/src/main/java/com/knud4/an/notice/dto/NoticeDTO.java
@@ -27,9 +27,11 @@ public class NoticeDTO {
 
     private LocalDateTime createdDate;
 
-    private String writer;
+    private Writer writer;
 
     private String releaseLine;
+
+    private Boolean isMine;
 
     public NoticeDTO(Notice notice) {
         this.id = notice.getId();
@@ -39,12 +41,20 @@ public class NoticeDTO {
         this.range = notice.getRange();
         this.createdDate = notice.getCreatedDate();
         this.releaseLine = notice.getReleaseLine();
-        this.writer = notice.getWriter().getName();
+        this.writer = new Writer(notice.getWriter().getId(),
+                notice.getWriter().getName());
     }
 
     public static List<NoticeDTO> entityListToDTOList(List<Notice> notices) {
         List<NoticeDTO> noticeDTOList = new ArrayList<>();
         for(Notice notice : notices) noticeDTOList.add(new NoticeDTO(notice));
         return noticeDTOList;
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class Writer {
+        Long id;
+        String name;
     }
 }

--- a/src/main/java/com/knud4/an/notice/entity/Notice.java
+++ b/src/main/java/com/knud4/an/notice/entity/Notice.java
@@ -2,7 +2,7 @@ package com.knud4.an.notice.entity;
 
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.board.Board;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,11 +20,11 @@ public class Notice extends Board {
     private String releaseLine;
 
     @Builder
-    public Notice(String title, String content, Profile writer, Range range, LocalDateTime expiredDate, String releaseLine) {
+    public Notice(String title, String content, Profile writer, Scope scope, LocalDateTime expiredDate, String releaseLine) {
         this.setContent(content);
         this.setTitle(title);
         this.setWriter(writer);
-        this.setRange(range);
+        this.setScope(scope);
 
         this.expiredDate = expiredDate;
         this.releaseLine = releaseLine;

--- a/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
@@ -24,39 +24,49 @@ public class NoticeRepository {
         return Optional.ofNullable(em.find(Notice.class, id));
     }
 
-    public List<Notice> findAll(int page, int count) {
-        return em.createQuery("select n from Notice n order by n.id desc", Notice.class)
+    public List<Notice> findAll(int page, int count, boolean desc) {
+        String query = "select n from Notice n order by n.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Notice.class)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Notice> findBeforeExpire(LocalDateTime expiredDate, int page, int count) {
-        return em.createQuery("select n from Notice n where n.expiredDate <= :expiredDate order by n.id desc", Notice.class)
+    public List<Notice> findBeforeExpire(LocalDateTime expiredDate, int page, int count, boolean desc) {
+        String query = "select n from Notice n where n.expiredDate <= :expiredDate order by n.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Notice.class)
                 .setParameter("expiredDate", expiredDate)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Notice> findByLine(String releaseLine, int page, int count) {
-        return em.createQuery("select n from Notice n where n.releaseLine = :releaseLine order by n.id desc", Notice.class)
+    public List<Notice> findByLine(String releaseLine, int page, int count, boolean desc) {
+        String query = "select n from Notice n where n.releaseLine = :releaseLine order by n.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Notice.class)
                 .setParameter("releaseLine", releaseLine)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Notice> findByScope(Scope scope, int page, int count) {
-        return em.createQuery("select n from Notice n where n.scope = :scope order by n.id desc", Notice.class)
+    public List<Notice> findByScope(Scope scope, int page, int count, boolean desc) {
+        String query = "select n from Notice n where n.scope = :scope order by n.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Notice.class)
                 .setParameter("scope", scope)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Notice> findByScopeAndLine(Scope scope, String releaseLine, int page, int count) {
-        return em.createQuery("select n from Notice n where n.scope = :scope and n.releaseLine = :releaseLine order by n.id desc", Notice.class)
+    public List<Notice> findByScopeAndLine(Scope scope, String releaseLine, int page, int count, boolean desc) {
+        String query = "select n from Notice n where n.scope = :scope and n.releaseLine = :releaseLine order by n.id";
+        if(desc) query += " desc";
+        return em.createQuery(query, Notice.class)
                 .setParameter("scope", scope)
                 .setParameter("releaseLine", releaseLine)
                 .setFirstResult((page-1)*count)

--- a/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/knud4/an/notice/repository/NoticeRepository.java
@@ -1,6 +1,6 @@
 package com.knud4.an.notice.repository;
 
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.notice.entity.Notice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -47,17 +47,17 @@ public class NoticeRepository {
                 .getResultList();
     }
 
-    public List<Notice> findByRange(Range range, int page, int count) {
-        return em.createQuery("select n from Notice n where n.range = :range order by n.id desc", Notice.class)
-                .setParameter("range", range)
+    public List<Notice> findByScope(Scope scope, int page, int count) {
+        return em.createQuery("select n from Notice n where n.scope = :scope order by n.id desc", Notice.class)
+                .setParameter("scope", scope)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)
                 .getResultList();
     }
 
-    public List<Notice> findByRangeAndLine(Range range, String releaseLine, int page, int count) {
-        return em.createQuery("select n from Notice n where n.range = :range and n.releaseLine = :releaseLine order by n.id desc", Notice.class)
-                .setParameter("range", range)
+    public List<Notice> findByScopeAndLine(Scope scope, String releaseLine, int page, int count) {
+        return em.createQuery("select n from Notice n where n.scope = :scope and n.releaseLine = :releaseLine order by n.id desc", Notice.class)
+                .setParameter("scope", scope)
                 .setParameter("releaseLine", releaseLine)
                 .setFirstResult((page-1)*count)
                 .setMaxResults(count)

--- a/src/main/java/com/knud4/an/notice/service/NoticeService.java
+++ b/src/main/java/com/knud4/an/notice/service/NoticeService.java
@@ -54,16 +54,17 @@ public class NoticeService {
 
     public List<Notice> findAll(int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
-        if(account.getRole().equals(Role.ROLE_MANAGER)) return noticeRepository.findAll(page, count);
+        if(account.getRole().equals(Role.ROLE_MANAGER)) return noticeRepository.findAll(page, count, true);
 
-        List<Notice> findNotices = noticeRepository.findByScope(Scope.ALL, page, count);
-        findNotices.addAll(noticeRepository.findByScopeAndLine(Scope.LINE, account.getLine().getName(), page, count));
+        List<Notice> findNotices = noticeRepository.findByScope(Scope.ALL, page, count, false);
+        findNotices.addAll(noticeRepository.findByScopeAndLine(Scope.LINE, account.getLine().getName(), page, count, false));
+        findNotices.sort((o1, o2) -> Long.compare(o2.getId(), o1.getId()));
         return findNotices;
     }
 
     public List<Notice> findAllMyLine(int page, int count, Long accountId) {
         Account account = accountRepository.findAccountById(accountId);
-        return noticeRepository.findByLine(account.getLine().getName(), page, count);
+        return noticeRepository.findByLine(account.getLine().getName(), page, count, true);
     }
 
     @Transactional

--- a/src/main/java/com/knud4/an/notice/service/NoticeService.java
+++ b/src/main/java/com/knud4/an/notice/service/NoticeService.java
@@ -4,7 +4,7 @@ import com.knud4.an.account.entity.Account;
 import com.knud4.an.account.entity.Profile;
 import com.knud4.an.account.entity.Role;
 import com.knud4.an.account.repository.AccountRepository;
-import com.knud4.an.board.Range;
+import com.knud4.an.board.Scope;
 import com.knud4.an.exception.NotAuthenticatedException;
 import com.knud4.an.exception.NotFoundException;
 import com.knud4.an.notice.dto.CreateNoticeForm;
@@ -32,7 +32,7 @@ public class NoticeService {
                 .writer(writer)
                 .title(form.getTitle())
                 .content(form.getContent())
-                .range(form.getRange())
+                .scope(form.getScope())
                 .releaseLine(form.getReleaseLine())
                 .expiredDate(form.getExpiredDate())
                 .build();
@@ -43,7 +43,7 @@ public class NoticeService {
     public Notice findNoticeById(Long noticeId, Long accountId) {
         Notice findNotice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new NotFoundException("공지글을 찾을 수 없습니다."));
-        if(findNotice.getRange() == Range.LINE) {
+        if(findNotice.getScope() == Scope.LINE) {
             Account account = accountRepository.findAccountById(accountId);
             if(!account.getLine().getName().equals(findNotice.getReleaseLine())) {
                 throw new NotAuthenticatedException("접근 권한이 없습니다.");
@@ -56,8 +56,8 @@ public class NoticeService {
         Account account = accountRepository.findAccountById(accountId);
         if(account.getRole().equals(Role.ROLE_MANAGER)) return noticeRepository.findAll(page, count);
 
-        List<Notice> findNotices = noticeRepository.findByRange(Range.ALL, page, count);
-        findNotices.addAll(noticeRepository.findByRangeAndLine(Range.LINE, account.getLine().getName(), page, count));
+        List<Notice> findNotices = noticeRepository.findByScope(Scope.ALL, page, count);
+        findNotices.addAll(noticeRepository.findByScopeAndLine(Scope.LINE, account.getLine().getName(), page, count));
         return findNotices;
     }
 
@@ -72,7 +72,7 @@ public class NoticeService {
                 .orElseThrow(() -> new NotFoundException("공지글을 찾을 수 없습니다."));
         notice.changeTitle(noticeDTO.getTitle());
         notice.changeContent(noticeDTO.getContent());
-        notice.changeRange(noticeDTO.getRange());
+        notice.changeScope(noticeDTO.getScope());
         notice.changeExpiredDate(noticeDTO.getExpiredDate());
         notice.changeReleaseLine(noticeDTO.getReleaseLine());
     }

--- a/src/main/java/com/knud4/an/notice/service/NoticeService.java
+++ b/src/main/java/com/knud4/an/notice/service/NoticeService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -90,5 +91,9 @@ public class NoticeService {
     public Boolean isLastPage(int page, int count) {
         Long noticeCnt = noticeRepository.findNoticeCount();
         return (long) (page + 2) * count >= noticeCnt;
+    }
+
+    public Boolean isMine(Notice notice, Long accountId) {
+        return Objects.equals(notice.getWriter().getAccount().getId(), accountId);
     }
 }


### PR DESCRIPTION
## PR 요약

1. Community, Notice, Comment 응답 로직 수정합니다.

## 변경 사항

1. Board 상속받는 도메인 응답 로직 writerId, isMine 추가
2. Writer의 Range를 Scope로 변경 및 likes, enum을 string으로 저장 등 컬럼 수정
3. Community, Notice, Comment 목록 정렬 수정

## 참고 사항

1. repository 전체 조회 함수에 desc:Boolean 파라미터 추가했습니다.
