### PR TITLE
Refactor: 메세징 예외 분리, 메세징 반환 헤더에 메세지 타입 포함

### DIFF
--- a/src/main/java/com/knud4/an/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/knud4/an/exception/handler/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.knud4.an.exception.handler;
 
 import com.knud4.an.exception.CookieNotFoundException;
-import com.knud4.an.exception.IllegalMessagingException;
+import com.knud4.an.exception.websocket.IllegalMessagingException;
 import com.knud4.an.exception.NotAuthenticatedException;
 import com.knud4.an.exception.NotFoundException;
 import com.knud4.an.utils.api.ApiUtil;

--- a/src/main/java/com/knud4/an/exception/websocket/IllegalMessagingException.java
+++ b/src/main/java/com/knud4/an/exception/websocket/IllegalMessagingException.java
@@ -1,4 +1,4 @@
-package com.knud4.an.exception;
+package com.knud4.an.exception.websocket;
 
 public class IllegalMessagingException extends RuntimeException{
     public IllegalMessagingException(String message) {

--- a/src/main/java/com/knud4/an/websocket/controller/AlertController.java
+++ b/src/main/java/com/knud4/an/websocket/controller/AlertController.java
@@ -1,9 +1,9 @@
 package com.knud4.an.websocket.controller;
 
-import com.knud4.an.exception.IllegalMessagingException;
-import com.knud4.an.utils.redis.RedisUtil;
+import com.knud4.an.exception.websocket.IllegalMessagingException;
 import com.knud4.an.websocket.dto.AcceptDTO;
 import com.knud4.an.websocket.dto.MessageDTO;
+import com.knud4.an.utils.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -12,6 +12,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
@@ -44,7 +46,10 @@ public class AlertController {
         redisUtil.set(line+house, true);
         redisUtil.expire(line+house, 600);
 
-        template.convertAndSend("/sub/line/" + line, result.toString());
+        Map<String, Object> header = new HashMap<>();
+        header.put("type", "alert");
+
+        template.convertAndSend("/sub/line/" + line, result.toString(), header);
     }
 
     @MessageMapping(value = "/accept")
@@ -69,6 +74,11 @@ public class AlertController {
         result.put("accept_house", house);
         result.put("target_house", acceptDTO.getTarget());
 
-        template.convertAndSend("/sub/line/" + line, result.toString());
+        Map<String, Object> header = new HashMap<>();
+        header.put("type", "accept");
+
+        template.convertAndSend("/sub/line/" + line, result.toString(), header);
+
+        redisUtil.del(line+acceptDTO.getTarget());
     }
 }

--- a/src/main/java/com/knud4/an/websocket/interceptor/StompInboundInterceptor.java
+++ b/src/main/java/com/knud4/an/websocket/interceptor/StompInboundInterceptor.java
@@ -3,6 +3,7 @@ package com.knud4.an.websocket.interceptor;
 import com.knud4.an.account.entity.Account;
 import com.knud4.an.account.repository.AccountRepository;
 import com.knud4.an.exception.NotFoundException;
+import com.knud4.an.exception.websocket.IllegalMessagingException;
 import com.knud4.an.house.entity.House;
 import com.knud4.an.house.repository.HouseRepository;
 import com.knud4.an.line.entity.Line;
@@ -96,10 +97,10 @@ public class StompInboundInterceptor implements ChannelInterceptor {
 
         if (destination != null && destination.startsWith(SUB_LINE_PREFIX)) {
             if (!destination.replace(SUB_LINE_PREFIX, "").equals(lineName)) {
-                throw new IllegalStateException("요청 라인 이름이 잘못되었습니다.");
+                throw new IllegalMessagingException("요청 라인 이름이 잘못되었습니다.");
             }
         } else {
-            throw new IllegalStateException("요청 형식이 잘못되었습니다.");
+            throw new IllegalMessagingException("요청 형식이 잘못되었습니다.");
         }
     }
 
@@ -110,14 +111,14 @@ public class StompInboundInterceptor implements ChannelInterceptor {
     private Map<String, Object> getHouseInfoByAuthorizationHeader(StompHeaderAccessor headerAccessor) {
         List<String> authorization = headerAccessor.getNativeHeader("Authorization");
         if (authorization == null || authorization.size() != 1) {
-            throw new NotFoundException("인증 정보를 찾을 수 없습니다.");
+            throw new IllegalMessagingException("인증 정보를 찾을 수 없습니다.");
         }
 
         String token = authorization.get(0);
         Long accountId = jwtProvider.getAccountIdFromToken(token);
 
         Account account = accountRepository.findAccountById(accountId)
-                .orElseThrow(() -> new NotFoundException("계정이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalMessagingException("계정이 존재하지 않습니다."));
         Line line = lineRepository.findById(account.getLine().getId());
         House house = houseRepository.findById(account.getHouse().getId());
 


### PR DESCRIPTION
## PR 요약

1. 메세징 예외 분리, 메세징 반환 헤더에 메세지 타입 포함

## 변경 사항

1. 메세징 프로토콜 통신에서 발생하는 예외를 분리하여 관리합니다.
2. 클라이언트에서 사용할 수 있는 메세징 헤더를 포함합니다.

## 참고 사항

1.
